### PR TITLE
Fix JSON escaping in AppleScript

### DIFF
--- a/export-notes.applescript
+++ b/export-notes.applescript
@@ -1,6 +1,6 @@
 on run argv
     set notesList to {}
-    
+
     tell application "Notes"
         set theAccounts to every account
         repeat with anAccount in theAccounts
@@ -9,7 +9,7 @@ on run argv
             repeat with aFolder in theFolders
                 set folderName to name of aFolder
                 set theNotes to notes of aFolder
-                
+
                 repeat with theNote in theNotes
                     -- Get note data
                     set noteTitle to name of theNote
@@ -17,13 +17,13 @@ on run argv
                     set noteId to id of theNote
                     set noteCreationDate to creation date of theNote
                     set noteModificationDate to modification date of theNote
-                    
+
                     -- Clean strings by removing problematic characters
                     set cleanTitle to my cleanForJson(noteTitle)
                     set cleanContent to my cleanForJson(noteContent)
                     set cleanFolder to my cleanForJson(folderName)
                     set cleanAccount to my cleanForJson(accountName)
-                    
+
                     -- Create JSON object
                     set noteData to "{"
                     set noteData to noteData & "\"title\":\"" & cleanTitle & "\","
@@ -34,13 +34,13 @@ on run argv
                     set noteData to noteData & "\"created\":\"" & ((noteCreationDate as text)) & "\","
                     set noteData to noteData & "\"modified\":\"" & ((noteModificationDate as text)) & "\""
                     set noteData to noteData & "}"
-                    
+
                     set end of notesList to noteData
                 end repeat
             end repeat
         end repeat
     end tell
-    
+
     return "[" & (my joinList(notesList, ",")) & "]"
 end run
 
@@ -53,10 +53,13 @@ on joinList(theList, theDelimiter)
 end joinList
 
 on cleanForJson(str)
-    set str to my replaceText(str, "\"", "'") -- replace quotes with single quotes
-    set str to my replaceText(str, "\n", " ") -- replace newlines with spaces
-    set str to my replaceText(str, "\r", " ") -- replace returns with spaces
-    set str to my replaceText(str, "\t", " ") -- replace tabs with spaces
+    -- Replace these characters in this specific order
+    set str to my replaceText(str, "\\", "\\\\") -- Escape backslashes first
+    set str to my replaceText(str, "\"", "\\\"") -- Escape double quotes
+    set str to my replaceText(str, "\n", "\\n") -- Replace newlines with \n
+    set str to my replaceText(str, "\r", "\\r") -- Replace returns with \r
+    set str to my replaceText(str, "\t", "\\t") -- Replace tabs with \t
+    set str to my replaceText(str, "/", "\\/") -- Escape forward slashes
     return str
 end cleanForJson
 


### PR DESCRIPTION
Fixed (Error: Failed to parse JSON output from AppleScript Caused by:
    invalid escape at line 1 column 11492)